### PR TITLE
Add JSON Schema validation and `validate` CLI command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+validate = [
+  "jsonschema>=4.0.0",
+]
 pdf = [
   "qrcode[pil]>=7.4.2",
   "reportlab>=4.0.0",
@@ -31,6 +34,7 @@ pdf = [
 ]
 test = [
   "pytest>=8.0.0",
+  "jsonschema>=4.0.0",
 ]
 
 [project.scripts]

--- a/schemas/envelope.schema.json
+++ b/schemas/envelope.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rosetta-envelope.local/schemas/envelope.schema.json",
+  "title": "Rosetta Envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol",
+    "version",
+    "document_id",
+    "document_type",
+    "created_at_unix",
+    "fields",
+    "metadata",
+    "payload_hash"
+  ],
+  "properties": {
+    "protocol": {"type": "string", "const": "rosetta-envelope"},
+    "version": {"type": "string", "minLength": 1},
+    "document_id": {"type": "string", "minLength": 1},
+    "document_type": {"type": "string", "minLength": 1},
+    "created_at_unix": {"type": "integer", "minimum": 0},
+    "issuer": {"type": ["string", "null"]},
+    "source_hash": {"type": ["string", "null"]},
+    "fields": {"type": "object"},
+    "metadata": {"type": "object"},
+    "payload_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {"type": "string", "minLength": 1},
+        "value": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/src/rosetta_envelope/__init__.py
+++ b/src/rosetta_envelope/__init__.py
@@ -20,4 +20,8 @@ __all__ = [
     "sha256_hex",
     "sign_hmac_demo",
     "verify_envelope",
+    "EnvelopeValidationError",
+    "validate_envelope",
 ]
+
+from .validation import EnvelopeValidationError, validate_envelope

--- a/src/rosetta_envelope/cli.py
+++ b/src/rosetta_envelope/cli.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .core import build_envelope, decode_qr_payload, encode_qr_payload, verify_envelope
 from .pdf import generate_simple_pdf
+from .validation import EnvelopeValidationError, validate_envelope
 
 
 def _load_json(path: str | Path) -> dict[str, Any]:
@@ -79,6 +80,21 @@ def cmd_generate_demo(args: argparse.Namespace) -> int:
     return 0
 
 
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    envelope = _load_json(args.file)
+    try:
+        validate_envelope(envelope)
+    except EnvelopeValidationError as exc:
+        print(f"Invalid envelope: {exc}")
+        return 1
+    except RuntimeError as exc:
+        print(str(exc))
+        return 2
+
+    print("Envelope is valid.")
+    return 0
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="rosetta-envelope")
     sub = parser.add_subparsers(required=True)
@@ -97,6 +113,10 @@ def build_parser() -> argparse.ArgumentParser:
     demo.add_argument("--output", default="examples/out/demo.pdf")
     demo.add_argument("--secret", default="demo-secret")
     demo.set_defaults(func=cmd_generate_demo)
+
+    validate = sub.add_parser("validate", help="Validate an envelope JSON file against the schema.")
+    validate.add_argument("file", help="Envelope JSON file to validate.")
+    validate.set_defaults(func=cmd_validate)
 
     return parser
 

--- a/src/rosetta_envelope/validation.py
+++ b/src/rosetta_envelope/validation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class EnvelopeValidationError(ValueError):
+    """Raised when an envelope fails JSON Schema validation."""
+
+
+def _load_schema() -> dict[str, Any]:
+    schema_path = Path(__file__).resolve().parents[2] / "schemas" / "envelope.schema.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def validate_envelope(envelope: dict[str, Any]) -> None:
+    """Validate a Rosetta Envelope payload against the JSON Schema."""
+    try:
+        import jsonschema
+    except ImportError as exc:
+        raise RuntimeError(
+            "Validation requires optional dependency 'jsonschema'. Install with: pip install -e '.[validate]'"
+        ) from exc
+
+    schema = _load_schema()
+
+    try:
+        jsonschema.validate(instance=envelope, schema=schema)
+    except jsonschema.ValidationError as exc:
+        path = " -> ".join(str(part) for part in exc.absolute_path) or "<root>"
+        raise EnvelopeValidationError(f"Envelope validation failed at {path}: {exc.message}") from exc

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,45 @@
+import json
+
+import pytest
+
+from rosetta_envelope import build_envelope
+from rosetta_envelope.cli import main
+from rosetta_envelope.validation import EnvelopeValidationError, validate_envelope
+
+
+jsonschema = pytest.importorskip("jsonschema")
+
+
+def test_validate_envelope_valid_payload():
+    envelope = build_envelope(document_type="invoice", fields={"amount": 100})
+    validate_envelope(envelope)
+
+
+def test_validate_envelope_invalid_payload_message_is_readable():
+    envelope = build_envelope(document_type="invoice", fields={"amount": 100})
+    del envelope["payload_hash"]
+
+    with pytest.raises(EnvelopeValidationError) as exc_info:
+        validate_envelope(envelope)
+
+    message = str(exc_info.value)
+    assert "Envelope validation failed" in message
+    assert "payload_hash" in message
+
+
+def test_cli_validate_command(tmp_path, capsys, monkeypatch):
+    envelope = build_envelope(document_type="invoice", fields={"amount": 100})
+    valid_file = tmp_path / "valid.json"
+    valid_file.write_text(json.dumps(envelope), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["rosetta-envelope", "validate", str(valid_file)])
+    assert main() == 0
+    assert "Envelope is valid." in capsys.readouterr().out
+
+    envelope.pop("payload_hash")
+    invalid_file = tmp_path / "invalid.json"
+    invalid_file.write_text(json.dumps(envelope), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["rosetta-envelope", "validate", str(invalid_file)])
+    assert main() == 1
+    assert "Invalid envelope:" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Ensure Rosetta Envelope payloads follow a predictable shape so downstream tools can rely on core fields like `payload_hash` and `fields`. 
- Provide human-readable validation failures to make debugging and integrations easier. 
- Keep validation optional to avoid adding runtime dependencies for users who do not need it.

### Description

- Add a JSON Schema at `schemas/envelope.schema.json` that defines required core fields, hash format, optional `signature` structure, and disallows additional properties. 
- Implement `validate_envelope(envelope)` and `EnvelopeValidationError` in `src/rosetta_envelope/validation.py`, with a friendly error when `jsonschema` is not installed. 
- Add a CLI command `rosetta-envelope validate <file>` in `src/rosetta_envelope/cli.py` that prints readable messages and returns stable exit codes for valid, invalid, and missing-dependency cases. 
- Add an optional dependency group `validate` (`jsonschema`) in `pyproject.toml`, include `jsonschema` in the `test` extras, export validation helpers via `src/rosetta_envelope/__init__.py`, and add tests in `tests/test_validation.py`.

### Testing

- Ran unit tests with `PYTHONPATH=src pytest -q` which passed (`3 passed, 1 skipped`).
- Added `tests/test_validation.py` covering a valid envelope, a readable failure when `payload_hash` is missing, and the CLI `validate` command behavior. 
- Attempted `pip install -e '.[test]'` to exercise install-time extras but it failed in this environment due to network/proxy restrictions when resolving build dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2389e23508325a74b43bf1b6b5150)