### PR TITLE
Add PDF metadata extraction and read-pdf CLI command

### DIFF
--- a/src/rosetta_envelope/cli.py
+++ b/src/rosetta_envelope/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .core import build_envelope, decode_qr_payload, encode_qr_payload, verify_envelope
-from .pdf import generate_simple_pdf
+from .pdf import generate_simple_pdf, read_envelope_from_pdf
 from .validation import EnvelopeValidationError, validate_envelope
 
 
@@ -80,6 +80,19 @@ def cmd_generate_demo(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_read_pdf(args: argparse.Namespace) -> int:
+    try:
+        envelope = read_envelope_from_pdf(args.path)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 2
+    except ValueError as exc:
+        print(f"Could not read envelope from PDF: {exc}")
+        return 1
+
+    print(json.dumps(envelope, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
 
 def cmd_validate(args: argparse.Namespace) -> int:
     envelope = _load_json(args.file)
@@ -113,6 +126,10 @@ def build_parser() -> argparse.ArgumentParser:
     demo.add_argument("--output", default="examples/out/demo.pdf")
     demo.add_argument("--secret", default="demo-secret")
     demo.set_defaults(func=cmd_generate_demo)
+
+    read_pdf = sub.add_parser("read-pdf", help="Read Rosetta Envelope JSON metadata from a PDF.")
+    read_pdf.add_argument("path", help="Path to PDF file.")
+    read_pdf.set_defaults(func=cmd_read_pdf)
 
     validate = sub.add_parser("validate", help="Validate an envelope JSON file against the schema.")
     validate.add_argument("file", help="Envelope JSON file to validate.")

--- a/src/rosetta_envelope/pdf.py
+++ b/src/rosetta_envelope/pdf.py
@@ -87,3 +87,27 @@ def generate_simple_pdf(
             output_path.write_bytes(base_pdf.read_bytes())
 
     return output_path
+
+
+def read_envelope_from_pdf(path: str | Path) -> dict[str, Any]:
+    """Read the Rosetta Envelope JSON payload from PDF metadata.
+
+    This only supports PDFs containing `/RosettaEnvelopeJson` metadata,
+    such as files produced by `generate_simple_pdf`.
+    """
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:
+        raise RuntimeError(
+            "PDF support requires optional dependencies. Install with: "
+            'pip install -e ".[pdf]"'
+        ) from exc
+
+    reader = PdfReader(str(path))
+    metadata = reader.metadata or {}
+    raw = metadata.get("/RosettaEnvelopeJson")
+    if raw is None:
+        raise ValueError("No /RosettaEnvelopeJson metadata found in PDF.")
+    if not isinstance(raw, str):
+        raw = str(raw)
+    return json.loads(raw)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from rosetta_envelope.core import build_envelope
+from rosetta_envelope.pdf import generate_simple_pdf, read_envelope_from_pdf
+
+
+def _pdf_dependencies_available() -> bool:
+    try:
+        import pypdf  # noqa: F401
+        import qrcode  # noqa: F401
+        import reportlab  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _pdf_dependencies_available(),
+    reason="PDF dependencies not installed; install with pip install -e '.[pdf]'",
+)
+
+
+def test_read_envelope_from_pdf_roundtrip(tmp_path):
+    envelope = build_envelope(
+        document_type="invoice",
+        document_id="demo-invoice-001",
+        issuer="Example Ltd",
+        fields={"invoice_number": "INV-2026-0001", "total_amount": 1280.0},
+        signature_secret="demo-secret",
+    )
+
+    pdf_path = tmp_path / "demo.pdf"
+    generate_simple_pdf(
+        output_path=pdf_path,
+        title="Demo Invoice",
+        lines=["Invoice number: INV-2026-0001"],
+        envelope=envelope,
+    )
+
+    decoded = read_envelope_from_pdf(pdf_path)
+    assert decoded == envelope
+
+
+def test_read_envelope_from_pdf_missing_metadata(tmp_path):
+    pdf_path = tmp_path / "plain.pdf"
+    generate_simple_pdf(
+        output_path=pdf_path,
+        title="Plain PDF",
+        lines=["No envelope metadata here"],
+        envelope=None,
+    )
+
+    with pytest.raises(ValueError, match="No /RosettaEnvelopeJson metadata"):
+        read_envelope_from_pdf(pdf_path)


### PR DESCRIPTION
### Motivation
- Provide a minimal, honest helper to extract Rosetta Envelope payloads that were embedded into PDF metadata, matching the existing demo producer (`generate_simple_pdf`).
- Expose this capability via the CLI so downstream tools can read `/RosettaEnvelopeJson` without OCR or layout heuristics.

### Description
- Add `read_envelope_from_pdf(path)` in `src/rosetta_envelope/pdf.py` which reads `/RosettaEnvelopeJson` from PDF metadata and returns the parsed JSON, with clear errors for missing optional PDF dependencies and missing metadata.
- Add a CLI command `rosetta-envelope read-pdf <path>` implemented as `cmd_read_pdf` in `src/rosetta_envelope/cli.py` that prints the envelope JSON and uses exit codes `0` (success), `1` (missing metadata), and `2` (missing PDF deps).
- Add `tests/test_pdf.py` which contains two tests (round-trip and missing-metadata) and is skipped at module level when optional PDF dependencies (`pypdf`, `qrcode`, `reportlab`) are not available.
- Keep the implementation intentionally scoped to PDFs carrying `/RosettaEnvelopeJson` (such as those produced by `generate_simple_pdf`) and preserve the project’s proof-of-concept positioning.

### Testing
- Running `pytest -q` in the unmodified environment initially failed due to import/install issues for the package in the environment (module import error during collection). 
- Attempting `pip install -e .[test]` failed to complete because build dependencies could not be fetched in this environment (network/proxy error).
- Running the test suite with `PYTHONPATH=src pytest -q` executed automated tests successfully, producing `3 passed, 3 skipped`, where PDF tests are skipped when optional PDF dependencies are absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23b07e3588325aff2f089ff4c591e)