### PR TITLE
Add committed demo envelope artifacts for first-time visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install -e ".[pdf,validate]"
 rosetta-envelope generate-demo --output examples/out/demo.pdf
 ```
 
+Want a quick look without running anything first? See committed demo artifacts in [`examples/demo/`](examples/demo/).
+
 ### 3) Read the envelope back from that PDF
 
 ```bash

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,0 +1,39 @@
+# Demo artifacts
+
+This folder contains small, committed demo artifacts for first-time visitors.
+
+## Included files
+
+- `demo_envelope.json`: A readable Rosetta Envelope payload for a demo invoice.
+
+## Optional PDF artifact
+
+The CLI can generate `demo.pdf` with embedded `/RosettaEnvelopeJson` metadata:
+
+```bash
+PYTHONPATH=src python -m rosetta_envelope.cli generate-demo --output examples/demo/demo.pdf
+```
+
+In this environment, optional PDF dependencies were unavailable, so `demo.pdf` is not committed here.
+
+## Read the envelope back
+
+If you generated `demo.pdf`, extract metadata with:
+
+```bash
+PYTHONPATH=src python -m rosetta_envelope.cli read-pdf examples/demo/demo.pdf
+```
+
+You can always inspect the committed JSON directly:
+
+```bash
+cat examples/demo/demo_envelope.json
+```
+
+## Validate the extracted JSON
+
+```bash
+PYTHONPATH=src python -m rosetta_envelope.cli validate examples/demo/demo_envelope.json
+```
+
+Validation requires the optional `jsonschema` dependency.

--- a/examples/demo/demo_envelope.json
+++ b/examples/demo/demo_envelope.json
@@ -1,0 +1,30 @@
+{
+  "created_at_unix": 1777483409,
+  "document_id": "demo-invoice-001",
+  "document_type": "invoice",
+  "fields": {
+    "buyer": "Acme Corp",
+    "currency": "GBP",
+    "invoice_number": "INV-2026-0001",
+    "line_items": [
+      {
+        "amount": 1280.0,
+        "description": "Demo sensor",
+        "quantity": 2,
+        "unit_price": 640.0
+      }
+    ],
+    "seller": "Example Ltd",
+    "total_amount": 1280.0
+  },
+  "issuer": "Example Ltd",
+  "metadata": {},
+  "payload_hash": "611acf74a98ea3d0ae5365a2beb332d19ab18a04a884cf4739863c4298742a51",
+  "protocol": "rosetta-envelope",
+  "signature": {
+    "algorithm": "HMAC-SHA256-DEMO",
+    "value": "c6c2efbfb1a89f9170c24b9a48ffd384a1f6f9d6e022494c389bf3067b7250f6"
+  },
+  "source_hash": null,
+  "version": "0.1.0"
+}


### PR DESCRIPTION
### Motivation

- Let GitHub visitors inspect a real Rosetta Envelope output without installing optional PDF or validation dependencies.
- Provide a small, committed example that demonstrates the CLI demo invoice payload and how to reproduce or validate it.

### Description

- Add `examples/demo/demo_envelope.json`, a readable Rosetta Envelope payload produced from the demo invoice data including `payload_hash` and the demo HMAC `signature`.
- Add `examples/demo/README.md` that explains what the demo files are, how to generate `demo.pdf` with `python -m rosetta_envelope.cli generate-demo --output examples/demo/demo.pdf`, how to read envelope metadata with `read-pdf`, and how to validate the JSON with `validate`.
- Update `README.md` quickstart to point first-time visitors to `examples/demo/` for a quick look without running the project.
- Keep `examples/out/` ignored and do not commit large binary PDFs; `demo.pdf` is documented as optional and was not committed because optional PDF dependencies were unavailable in this environment.

### Testing

- Ran `PYTHONPATH=src pytest -q` which completed successfully with `3 passed, 3 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23e3ce9488325aaab4723a8487f50)