### PR TITLE
docs: add compact README badges for GitHub visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rosetta Envelope
 
+[![Tests](https://img.shields.io/github/actions/workflow/status/YOUR_USERNAME/rosetta-envelope/tests.yml?label=tests)](../../actions/workflows/tests.yml) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE) [![Latest Release](https://img.shields.io/github/v/release/YOUR_USERNAME/rosetta-envelope)](../../releases) [![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue)](pyproject.toml)
+
 **Anti-OCR for generated documents: attach structure before AI has to guess it.**
 
 Rosetta Envelope is a small, open-source proof of concept for generated PDFs and paper documents.


### PR DESCRIPTION
### Motivation
- Improve first-glance clarity for GitHub visitors by surfacing key project signals (tests, license, release, and Python support) near the top of `README.md`.

### Description
- Inserted a single compact badge row under the project title in `README.md` with links for the tests workflow, MIT license, latest GitHub release, and Python `>=3.10` support.
- This is a documentation-only change and does not modify any core code or project behavior.

### Testing
- Attempted to run the test matrix with `python -m pip install -e '.[test]' && pytest -q` but dependency installation failed due to network/proxy restrictions in the environment preventing fetch of `setuptools>=68`.
- No automated tests in the repository were changed and no test failures were caused by this docs-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f245be89cc8325badb7efffbbaa106)